### PR TITLE
Player Death Fixes

### DIFF
--- a/ControllerProject/Assets/Scripts/CameraBehavior.cs
+++ b/ControllerProject/Assets/Scripts/CameraBehavior.cs
@@ -15,6 +15,7 @@ public class CameraBehavior : MonoBehaviour
     GameObject player1Obj;
     bool followPlayer=false;
     Vector3 newPos;
+    GameObject player2Obj;
     /// <summary>
     /// Start is called before the first frame update. Checks for players
     /// </summary>
@@ -39,6 +40,10 @@ public class CameraBehavior : MonoBehaviour
             {
                 followPlayer = true;
             }
+            if (player2Obj == null)
+            {
+                player2Obj = GameObject.Find("Grayboxed Bandit(Clone)");
+            }
             yield return new WaitForSeconds(1);
         }
     }
@@ -49,11 +54,27 @@ public class CameraBehavior : MonoBehaviour
     /// </summary>
     private void Update()
     {
-        if (followPlayer)
+        if (followPlayer&&player2Obj==null&&player1Obj!=null)
         {
             newPos = player1Obj.transform.position;
             newPos.z = -10;
             transform.position = newPos;
+        }
+        if (followPlayer && player2Obj != null && player1Obj!=null)
+        {
+            newPos = player1Obj.transform.position;
+            newPos.z = -10;
+            transform.position = newPos;
+        }
+        if (followPlayer && player2Obj!=null &&player1Obj==null)
+        {
+            newPos = player2Obj.transform.position;
+            newPos.z = -10;
+            transform.position = newPos;
+        }
+        if(player2Obj==null && player1Obj == null)
+        {
+            print("cam Stop");
         }
     }
 }

--- a/ControllerProject/Assets/Scripts/CharacterScripts/Bandit/BanditBehavior.cs
+++ b/ControllerProject/Assets/Scripts/CharacterScripts/Bandit/BanditBehavior.cs
@@ -61,12 +61,13 @@ public class BanditBehavior : MonoBehaviour
     [SerializeField] private GameObject firecrackerExplosive;
     [SerializeField] private GameObject cocktailExplosive;
     [SerializeField] private GameObject atkPoint;
-    [SerializeField] private int playerhealth = 100;
+    [SerializeField] private int playerhealth = 150;
     private bool weaponChanged = false;
     private int weaponNumber = 1;
     Coroutine stopMe;
     private GameObject player1;
     [SerializeField] private int cells;
+    public bool freeMove;
 
     private UIManagerBehavior uim;
 
@@ -435,6 +436,10 @@ public class BanditBehavior : MonoBehaviour
             canAttack = false;
         }
         ClampPlayer(transform.position);
+        if (playerhealth <= 0)
+        {
+            Destroy(gameObject);
+        }
     }
 
 
@@ -447,7 +452,7 @@ public class BanditBehavior : MonoBehaviour
     {
         Vector2 playerBind = pos;
 
-        if (player1 != null)
+        if (player1 != null && !freeMove)
         {
             Vector2 camPos = player1.transform.position;
             if (camPos.x - pos.x > 8f)

--- a/ControllerProject/Assets/Scripts/CharacterScripts/Enemies/Plant Demons/KamicactusBehavior.cs
+++ b/ControllerProject/Assets/Scripts/CharacterScripts/Enemies/Plant Demons/KamicactusBehavior.cs
@@ -50,18 +50,28 @@ public class KamicactusBehavior : MonoBehaviour
     {
         player1 = GameObject.Find("Grayboxed Sheriff(Clone)");
         player2 = GameObject.Find("Grayboxed Bandit(Clone");
-        target = 1;
-        if (player2 != null)
-        {
-            target = Random.Range(1, 2);
-        }
+        target = Random.Range(1,3);
         if (target == 1)
         {
-            targetObject = player1;
+            if (player1 != null)
+            {
+                targetObject = player1;
+            }
+            else
+            {
+                targetObject = player2;
+            }
         }
         else
         {
-            targetObject = player2;
+            if (player2 != null)
+            {
+                targetObject = player2;
+            }
+            else
+            {
+                targetObject = player1;
+            }
         }
         offset.x = 3;
         offset.y = 3;
@@ -80,6 +90,31 @@ public class KamicactusBehavior : MonoBehaviour
     void FixedUpdate()
     {
         TrackTargetPlayer(targetObject);
+        if (targetObject == null)
+        {
+            if (target == 1)
+            {
+                if (player1 != null)
+                {
+                    targetObject = player1;
+                }
+                else
+                {
+                    targetObject = player2;
+                }
+            }
+            else
+            {
+                if (player2 != null)
+                {
+                    targetObject = player2;
+                }
+                else
+                {
+                    targetObject = player1;
+                }
+            }
+        }
     }
 
     /// <summary>

--- a/ControllerProject/Assets/Scripts/CharacterScripts/Enemies/Plant Demons/LargeTumbleFiendBehavior.cs
+++ b/ControllerProject/Assets/Scripts/CharacterScripts/Enemies/Plant Demons/LargeTumbleFiendBehavior.cs
@@ -17,7 +17,7 @@ public class LargeTumbleFiendBehavior : MonoBehaviour
     [SerializeField] private GameObject smallTumble;
 
     //References to players and setting targets
-    private int target;
+    [SerializeField] private int target;
     private GameObject targetObject;
     [SerializeField] GameObject player1;
     [SerializeField] GameObject player2;
@@ -40,15 +40,30 @@ public class LargeTumbleFiendBehavior : MonoBehaviour
     {
         player1 = GameObject.Find("Grayboxed Sheriff(Clone)");
         player2 = GameObject.Find("Grayboxed Bandit(Clone)");
-        target = 1;
-        target = Random.Range(1, 2);
+        target = Random.Range(1, 3);
         if (target == 1)
         {
-            targetObject = player1;
+            if (player1 != null)
+            {
+                targetObject = player1;
+                print("target found");
+            }
+            else
+            {
+                targetObject = player2;
+            }
         }
         else
         {
-            targetObject = player2;
+            if (player2 != null)
+            {
+                targetObject = player2;
+                print("target found");
+            }
+            else
+            {
+                targetObject = player1;
+            }
         }
         offset.x = 3;
         offset.y = 3;
@@ -64,7 +79,23 @@ public class LargeTumbleFiendBehavior : MonoBehaviour
     /// </summary>
     void Update()
     {
-        TrackTargetPlayer(targetObject);
+        if (targetObject == null)
+        {
+            print("target lost");
+            if (player1 != null)
+            {
+                targetObject = player1;
+            }
+            else if (player2!=null)
+            {
+                targetObject = player2;
+            }
+            
+        }
+        if (targetObject != null)
+        {
+            TrackTargetPlayer(targetObject);
+        }
     }
 
     /// <summary>

--- a/ControllerProject/Assets/Scripts/CharacterScripts/Enemies/Plant Demons/StenoCerberusBehavior.cs
+++ b/ControllerProject/Assets/Scripts/CharacterScripts/Enemies/Plant Demons/StenoCerberusBehavior.cs
@@ -69,6 +69,33 @@ public class StenoCerberusBehavior : MonoBehaviour
         GameObject objectSpawned;
         for (; ; )
         {
+            if (targetObject == null)
+            {
+                if (target == 1)
+                {
+                    if (player1 != null)
+                    {
+                        targetObject = player1;
+                    }
+                    else
+                    {
+                        targetObject = player2;
+                    }
+                    target = 2;
+                }
+                else
+                {
+                    if (player2 != null)
+                    {
+                        targetObject = player2;
+                    }
+                    else
+                    {
+                        targetObject = player1;
+                    }
+                    target = 1;
+                }
+            }
             targetPos = targetObject.transform.position;
             distance.x = transform.position.x - targetPos.x;
             distance.y = transform.position.y - targetPos.y;
@@ -114,16 +141,27 @@ public class StenoCerberusBehavior : MonoBehaviour
     {
         if (target == 1)
         {
+            if (player1 != null)
+            {
+                targetObject = player1;
+            }
+            else
+            {
+                targetObject = player2;
+            }
             target = 2;
+        }
+        else
+        {
             if (player2 != null)
             {
                 targetObject = player2;
             }
-        }
-        else
-        {
+            else
+            {
+                targetObject = player1;
+            }
             target = 1;
-            targetObject = player1;
         }
         targetSwitchTimer = Random.Range(2, 10);
         yield return new WaitForSeconds(targetSwitchTimer);

--- a/ControllerProject/Assets/Scripts/CharacterScripts/Sheriff/SheriffBehavior.cs
+++ b/ControllerProject/Assets/Scripts/CharacterScripts/Sheriff/SheriffBehavior.cs
@@ -61,11 +61,13 @@ public class SheriffBehavior : MonoBehaviour
     [SerializeField] private GameObject shotgunBullet;
     [SerializeField] private GameObject pistolBullet;
     [SerializeField] private GameObject atkPoint;
-    [SerializeField] private int playerhealth = 100;
+    [SerializeField] private int playerhealth = 150;
     private bool weaponChanged = false;
     private int weaponNumber = 1;
     Coroutine stopMe;
     [SerializeField] private int cells;
+    BanditBehavior player2;
+    GameObject player2Obj;
     //public static SheriffBehavior instance;
     //public static GameObject player;
     //public static List<GameObject> playerList = new List<GameObject>();
@@ -490,6 +492,15 @@ public class SheriffBehavior : MonoBehaviour
         else
         {
             canAttack = false;
+        }
+
+        if (playerhealth <= 0)
+        {
+            if (player2Obj != null)
+            {
+                player2.freeMove = true;
+            }
+            Destroy(gameObject);
         }
     }
 

--- a/ControllerProject/Assets/Scripts/GameController.cs
+++ b/ControllerProject/Assets/Scripts/GameController.cs
@@ -27,6 +27,7 @@ public class GameController : MonoBehaviour
     private bool gameStarted=false;
     private int numToSpawn;
     private int spawnedAtOnce=6;
+    private bool startedSave;
 
 
     private int changeKamiRate;
@@ -36,6 +37,8 @@ public class GameController : MonoBehaviour
     //Player References
     GameObject player1Obj;
     SheriffBehavior player1;
+    GameObject player2Obj;
+    BanditBehavior player2;
 
 
     //Enemy Spawning
@@ -85,6 +88,10 @@ public class GameController : MonoBehaviour
             {
                 player1Obj = GameObject.Find("Grayboxed Sheriff(Clone)");
             }
+            if (player2Obj == null)
+            {
+                player2Obj = GameObject.Find("Grayboxed Bandit(Clone)");
+            }
             if (player1Obj != null&&!gameStarted)
             {
                 player1 = player1Obj.GetComponent<SheriffBehavior>();
@@ -101,6 +108,18 @@ public class GameController : MonoBehaviour
     /// </summary>
     void Update()
     {
+        if(player1Obj==null && player2Obj == null && gameStarted)
+        {
+            SceneManager.LoadScene("LoseScreen");
+        }
+        if (player2Obj == null)
+        {
+            player2Obj = GameObject.Find("Grayboxed Bandit(Clone)");
+        }
+        if (player2Obj != null)
+        {
+            player2 = player2Obj.GetComponent<BanditBehavior>();
+        }
         if (player1Obj != null)
         {
             if (enemyCounter <= 2 && enemySpawnNum < numToSpawn)
@@ -109,7 +128,8 @@ public class GameController : MonoBehaviour
             }
             else
             {
-                if (enemyCounter == 0 && wave != 9 && !wavePause && player1Obj != null)
+                if (enemyCounter == 0 && wave != 9 && !wavePause && player1Obj != 
+                    null)
                 {
                     print("dsghjgd");
                     StartCoroutine(WaveBreak());
@@ -117,10 +137,22 @@ public class GameController : MonoBehaviour
                 }
             }
 
-            if (player1.Playerhealth <= 0 && player1Obj != null)
+            if (player1Obj != null && player1.Playerhealth <= 0 && player2Obj == 
+                null)
             {
                 SceneManager.LoadScene("LoseScreen");
             }
+
+            if (player2Obj != null && player2.Playerhealth <= 0 && player1Obj ==
+                null)
+            {
+                SceneManager.LoadScene("LoseScreen");
+            }
+            /*if(player1Obj!=null && player2Obj!=null && player1.Playerhealth<=0 && 
+                player2.Playerhealth <= 0)
+            {
+                SceneManager.LoadScene("LoseScreen");
+            }*/
         }
     }
 


### PR DESCRIPTION
When all players are dead, the game ends. Enemies will pick a new target upon death of their current target. Camera will switch which player it is following as needed.